### PR TITLE
fix: remove Procfile to test running on Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: dummy_http --port $PORT


### PR DESCRIPTION
Sample Crystal buildpack app does not have a Procfile