### PR TITLE
Fix usage of Crystal 0.26's shards command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# hcs/Makefile
+# dummy-http/Makefile
 
 .PHONY: test
 
@@ -11,9 +11,8 @@ t : test
 # Don't forget : Makefiles use tabs indentation, not spaces !
 
 setup: ## Install crystal language and dependencies
-	@echo "Updating Homebrew ..."                 && brew update
 	@echo "Installing Crystal using Homebrew ..." && brew install crystal-lang
-	@echo "Installing Crystal dependencies ..."   && crystal deps
+	@echo "Installing Crystal dependencies ..."   && shards
 
 run: ## Run the app
 	@echo "Running application ..." && crystal run src/dummy_http.cr

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 # hcs/Makefile
 
+.PHONY: test
+
 # Aliases to everyday takss faster
 b : build
 r : run

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 # hcs/Makefile
 
+# Aliases to everyday takss faster
+b : build
+r : run
+s : setup
+t : test
+
 # Don't forget : Makefiles use tabs indentation, not spaces !
 
 setup: ## Install crystal language and dependencies

--- a/shard.lock
+++ b/shard.lock
@@ -6,7 +6,7 @@ shards:
 
   kemal:
     github: kemalcr/kemal
-    commit: b389022b35202319b59396f30b3cac87fd8d393a
+    version: 0.24.0
 
   kilt:
     github: jeromegn/kilt
@@ -18,5 +18,5 @@ shards:
 
   spec-kemal:
     github: kemalcr/spec-kemal
-    commit: 93ab608228ea6619d15555d1c77a3bcff29f1dba
+    version: 0.4.0
 

--- a/shard.lock
+++ b/shard.lock
@@ -1,8 +1,12 @@
 version: 1.0
 shards:
+  exception_page:
+    github: crystal-loot/exception_page
+    version: 0.1.1
+
   kemal:
     github: kemalcr/kemal
-    commit: f3f7e319ae8146b474569c18a2062bee0b1f79d5
+    commit: b389022b35202319b59396f30b3cac87fd8d393a
 
   kilt:
     github: jeromegn/kilt

--- a/shard.yml
+++ b/shard.yml
@@ -7,15 +7,15 @@ authors:
 dependencies:
   kemal:
     github: kemalcr/kemal
-    branch: master
+    version: "~> 0.24.0"
   spec-kemal:
     github: kemalcr/spec-kemal
-    branch: master
+    version: "~> 0.4.0"
 
 targets:
   http_dummy:
     main: src/dummy_http.cr
 
-crystal: 0.21.1
+crystal: 0.26.1
 
 license: MIT


### PR DESCRIPTION
Up to date shards coupled with the new `shards` command that replaces `crystal deps` make the app working again.